### PR TITLE
Fix issue 31

### DIFF
--- a/docker/Dockerfile.keras-py27
+++ b/docker/Dockerfile.keras-py27
@@ -38,9 +38,11 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
         python-pip \
         python-dev \
         && \
+    python -m $PIP_INSTALL \
+        pip \
+        && \
     $PIP_INSTALL \
         setuptools \
-        pip \
         && \
     $PIP_INSTALL \
         numpy \

--- a/generator/modules/python.py
+++ b/generator/modules/python.py
@@ -49,9 +49,11 @@ class Python(Module):
                 python-pip \
                 python-dev \
                 && \
+            python -m $PIP_INSTALL \
+                pip \
+                && \
             $PIP_INSTALL \
                 setuptools \
-                pip \
                 && \
             '''
         )).rstrip() + r'''


### PR DESCRIPTION
### Changes
-  Fix issue #31 
- Add `python -m` to run `pip` via Python interpreter to upgrade `pip`
  - I've referred user guide of pip on [running `pip`](https://pip.pypa.io/en/stable/user_guide/#id9):
    > If you cannot run the pip command directly (possibly because the location where it was installed isn't on your operating system's PATH) then you can run `pip` via the Python interpreter