### PR TITLE
Expose ubuntu-ver argument for generator.py and add extra packages for Ubuntu 18.04

### DIFF
--- a/generator/core/composer.py
+++ b/generator/core/composer.py
@@ -5,7 +5,7 @@ import functools
 
 class Composer(object):
 
-    def __init__(self, modules, cuda_ver, cudnn_ver, versions={}):
+    def __init__(self, modules, cuda_ver, cudnn_ver, ubuntu_ver='16.04', versions={}):
         if len(modules) == 0:
             raise ValueError('Modules should contain at least one module')
         pending = self._traverse(modules)
@@ -13,7 +13,7 @@ class Composer(object):
         self.instances = self._get_instances(versions)
         self.cuda_ver = cuda_ver
         self.cudnn_ver = cudnn_ver
-        self.ubuntu_ver = '16.04'
+        self.ubuntu_ver = ubuntu_ver
 
     def get(self):
         return self.modules
@@ -24,10 +24,7 @@ class Composer(object):
                 return ins.version
         return None
 
-    def to_dockerfile(self, ubuntu_ver):
-        if ubuntu_ver:
-            self.ubuntu_ver = ubuntu_ver
-
+    def to_dockerfile(self):
         def _indent(n, s):
             prefix = ' ' * 4 * n
             return ''.join(prefix + l for l in s.splitlines(True))

--- a/generator/core/composer.py
+++ b/generator/core/composer.py
@@ -13,6 +13,7 @@ class Composer(object):
         self.instances = self._get_instances(versions)
         self.cuda_ver = cuda_ver
         self.cudnn_ver = cudnn_ver
+        self.ubuntu_ver = '16.04'
 
     def get(self):
         return self.modules
@@ -23,7 +24,9 @@ class Composer(object):
                 return ins.version
         return None
 
-    def to_dockerfile(self, ubuntu_ver='16.04'):
+    def to_dockerfile(self, ubuntu_ver):
+        if ubuntu_ver:
+            self.ubuntu_ver = ubuntu_ver
 
         def _indent(n, s):
             prefix = ' ' * 4 * n
@@ -48,9 +51,9 @@ class Composer(object):
                        /etc/apt/sources.list.d/nvidia-ml.list && \
 
                 apt-get update && \
-            ''' % ('ubuntu:%s' % ubuntu_ver if self.cuda_ver is None
+            ''' % ('ubuntu:%s' % self.ubuntu_ver if self.cuda_ver is None
                    else 'nvidia/cuda:%s-cudnn%s-devel-ubuntu%s' % (
-                    self.cuda_ver, self.cudnn_ver, ubuntu_ver)),
+                    self.cuda_ver, self.cudnn_ver, self.ubuntu_ver)),
             '\n',
             '\n'.join([
                 ''.join([

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -22,6 +22,7 @@ def main():
     parser.add_argument('modules', nargs='*')
     parser.add_argument('--cuda-ver')
     parser.add_argument('--cudnn-ver')
+    parser.add_argument('--ubuntu-ver')
     args = parser.parse_args()
 
     in_modules = []
@@ -34,7 +35,7 @@ def main():
             versions[m] = terms[1]
     composer = Composer(in_modules, args.cuda_ver, args.cudnn_ver, versions)
     with open(args.path, 'w') as f:
-        f.write(composer.to_dockerfile())
+        f.write(composer.to_dockerfile(args.ubuntu_ver))
 
 
 if __name__ == "__main__":

--- a/generator/generate.py
+++ b/generator/generate.py
@@ -33,9 +33,9 @@ def main():
         in_modules.append(m)
         if len(terms) > 1:
             versions[m] = terms[1]
-    composer = Composer(in_modules, args.cuda_ver, args.cudnn_ver, versions)
+    composer = Composer(in_modules, args.cuda_ver, args.cudnn_ver, args.ubuntu_ver, versions)
     with open(args.path, 'w') as f:
-        f.write(composer.to_dockerfile(args.ubuntu_ver))
+        f.write(composer.to_dockerfile())
 
 
 if __name__ == "__main__":

--- a/generator/modules/python.py
+++ b/generator/modules/python.py
@@ -14,18 +14,22 @@ class Python(Module):
             raise NotImplementedError('unsupported python version')
 
     def build(self):
+        if self.composer.ubuntu_ver.startswith("18."):
+            distutils = "python3-distutils"
+        else:
+            distutils = "python3-distutils-extra"
         return (r'''
             DEBIAN_FRONTEND=noninteractive $APT_INSTALL \
                 python3-pip \
                 python3-dev \
-                python3-distutils \
+                %s \
                 && \
             ln -s /usr/bin/python3 /usr/local/bin/python && \
             pip3 --no-cache-dir install --upgrade pip && \
             $PIP_INSTALL \
                 setuptools \
                 && \
-            ''' if self.version == '3.5' else (
+            ''' % (distutils) if self.version == '3.5' else (
             r'''
             DEBIAN_FRONTEND=noninteractive $APT_INSTALL \
                 software-properties-common \
@@ -35,7 +39,7 @@ class Python(Module):
             DEBIAN_FRONTEND=noninteractive $APT_INSTALL \
                 python3.6 \
                 python3.6-dev \
-                python3-distutils \
+                %s \
                 && \
             wget -O ~/get-pip.py \
                 https://bootstrap.pypa.io/get-pip.py && \
@@ -45,7 +49,7 @@ class Python(Module):
             $PIP_INSTALL \
                 setuptools \
                 && \
-            ''' if self.version == '3.6' else
+            ''' % (distutils) if self.version == '3.6' else
             r'''
             DEBIAN_FRONTEND=noninteractive $APT_INSTALL \
                 python-pip \

--- a/generator/modules/python.py
+++ b/generator/modules/python.py
@@ -18,6 +18,7 @@ class Python(Module):
             DEBIAN_FRONTEND=noninteractive $APT_INSTALL \
                 python3-pip \
                 python3-dev \
+                python3-distutils \
                 && \
             ln -s /usr/bin/python3 /usr/local/bin/python && \
             pip3 --no-cache-dir install --upgrade pip && \
@@ -34,6 +35,7 @@ class Python(Module):
             DEBIAN_FRONTEND=noninteractive $APT_INSTALL \
                 python3.6 \
                 python3.6-dev \
+                python3-distutils \
                 && \
             wget -O ~/get-pip.py \
                 https://bootstrap.pypa.io/get-pip.py && \

--- a/generator/modules/tools.py
+++ b/generator/modules/tools.py
@@ -12,6 +12,7 @@ class Tools(Module):
         return r'''
             DEBIAN_FRONTEND=noninteractive $APT_INSTALL \
                 build-essential \
+                apt-utils \
                 ca-certificates \
                 cmake \
                 wget \


### PR DESCRIPTION
Hi there,

I saw that `ubuntu_ver` argument is supported in `to_dockerfile` function in `Composer` of generator but not exposed as command-line argument.
I made one to let users specify the desired version of Ubuntu (18.04 in my case).

Also added required packages to build on Ubuntu 18.04.


