### PR TITLE
Add option for use multicore when building `boost`

### DIFF
--- a/docker/Dockerfile.all-jupyter-py36-cpu
+++ b/docker/Dockerfile.all-jupyter-py36-cpu
@@ -140,7 +140,7 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
     tar -zxf ~/boost.tar.gz -C ~ && \
     cd ~/boost_* && \
     ./bootstrap.sh --with-python=python3.6 && \
-    ./b2 install --prefix=/usr/local && \
+    ./b2 install -j"$(nproc)" --prefix=/usr/local && \
 
 # ==================================================================
 # chainer

--- a/docker/Dockerfile.all-jupyter-py36-cu100
+++ b/docker/Dockerfile.all-jupyter-py36-cu100
@@ -139,7 +139,7 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
     tar -zxf ~/boost.tar.gz -C ~ && \
     cd ~/boost_* && \
     ./bootstrap.sh --with-python=python3.6 && \
-    ./b2 install --prefix=/usr/local && \
+    ./b2 install -j"$(nproc)" --prefix=/usr/local && \
 
 # ==================================================================
 # chainer

--- a/docker/Dockerfile.all-py36-cpu
+++ b/docker/Dockerfile.all-py36-cpu
@@ -139,7 +139,7 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
     tar -zxf ~/boost.tar.gz -C ~ && \
     cd ~/boost_* && \
     ./bootstrap.sh --with-python=python3.6 && \
-    ./b2 install --prefix=/usr/local && \
+    ./b2 install -j"$(nproc)" --prefix=/usr/local && \
 
 # ==================================================================
 # chainer

--- a/docker/Dockerfile.all-py36-cu100
+++ b/docker/Dockerfile.all-py36-cu100
@@ -138,7 +138,7 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
     tar -zxf ~/boost.tar.gz -C ~ && \
     cd ~/boost_* && \
     ./bootstrap.sh --with-python=python3.6 && \
-    ./b2 install --prefix=/usr/local && \
+    ./b2 install -j"$(nproc)" --prefix=/usr/local && \
 
 # ==================================================================
 # chainer

--- a/docker/Dockerfile.caffe-py36-cpu
+++ b/docker/Dockerfile.caffe-py36-cpu
@@ -75,7 +75,7 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
     tar -zxf ~/boost.tar.gz -C ~ && \
     cd ~/boost_* && \
     ./bootstrap.sh --with-python=python3.6 && \
-    ./b2 install --prefix=/usr/local && \
+    ./b2 install -j"$(nproc)" --prefix=/usr/local && \
 
 # ==================================================================
 # opencv

--- a/docker/Dockerfile.caffe-py36-cu100
+++ b/docker/Dockerfile.caffe-py36-cu100
@@ -75,7 +75,7 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
     tar -zxf ~/boost.tar.gz -C ~ && \
     cd ~/boost_* && \
     ./bootstrap.sh --with-python=python3.6 && \
-    ./b2 install --prefix=/usr/local && \
+    ./b2 install -j"$(nproc)" --prefix=/usr/local && \
 
 # ==================================================================
 # opencv

--- a/docker/Dockerfile.cntk-py36-cpu
+++ b/docker/Dockerfile.cntk-py36-cpu
@@ -75,7 +75,7 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
     tar -zxf ~/boost.tar.gz -C ~ && \
     cd ~/boost_* && \
     ./bootstrap.sh --with-python=python3.6 && \
-    ./b2 install --prefix=/usr/local && \
+    ./b2 install -j"$(nproc)" --prefix=/usr/local && \
 
 # ==================================================================
 # opencv

--- a/docker/Dockerfile.cntk-py36-cu100
+++ b/docker/Dockerfile.cntk-py36-cu100
@@ -75,7 +75,7 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
     tar -zxf ~/boost.tar.gz -C ~ && \
     cd ~/boost_* && \
     ./bootstrap.sh --with-python=python3.6 && \
-    ./b2 install --prefix=/usr/local && \
+    ./b2 install -j"$(nproc)" --prefix=/usr/local && \
 
 # ==================================================================
 # opencv

--- a/generator/modules/boost.py
+++ b/generator/modules/boost.py
@@ -25,6 +25,6 @@ class Boost(Module):
             tar -zxf ~/boost.tar.gz -C ~ && \
             cd ~/boost_* && \
             ./bootstrap.sh --with-python=python%s && \
-            ./b2 install --prefix=/usr/local && \
+            ./b2 install -j"$(nproc)" --prefix=/usr/local && \
             ''' % pyver
         )


### PR DESCRIPTION
Hi there,

I added `-j N` option on build command of `boost` for speed up build time.

https://boostorg.github.io/build/manual/develop/index.html
> -j N
Run up to N commands in parallel. Default number of jobs is 1.