### PR TITLE
Getting torchvision from Github.

### DIFF
--- a/docker/Dockerfile.all-jupyter-py36-cpu
+++ b/docker/Dockerfile.all-jupyter-py36-cpu
@@ -197,8 +197,12 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
         enum34 \
         pyyaml \
         typing \
-    	torchvision_nightly \
+    	torch \
         && \
+
+    $PIP_INSTALL \
+    "git+https://github.com/pytorch/vision.git" && \
+
     $PIP_INSTALL \
         torch_nightly -f \
         https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html \

--- a/docker/Dockerfile.all-jupyter-py36-cu100
+++ b/docker/Dockerfile.all-jupyter-py36-cu100
@@ -197,8 +197,12 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
         enum34 \
         pyyaml \
         typing \
-    	torchvision_nightly \
+    	torch \
         && \
+
+    $PIP_INSTALL \
+    "git+https://github.com/pytorch/vision.git" && \
+
     $PIP_INSTALL \
         torch_nightly -f \
         https://download.pytorch.org/whl/nightly/cu100/torch_nightly.html \

--- a/docker/Dockerfile.all-py36-cpu
+++ b/docker/Dockerfile.all-py36-cpu
@@ -188,8 +188,12 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
         enum34 \
         pyyaml \
         typing \
-    	torchvision_nightly \
+    	torch \
         && \
+
+    $PIP_INSTALL \
+    "git+https://github.com/pytorch/vision.git" && \
+
     $PIP_INSTALL \
         torch_nightly -f \
         https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html \

--- a/docker/Dockerfile.all-py36-cu100
+++ b/docker/Dockerfile.all-py36-cu100
@@ -188,8 +188,12 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
         enum34 \
         pyyaml \
         typing \
-    	torchvision_nightly \
+    	torch \
         && \
+
+    $PIP_INSTALL \
+    "git+https://github.com/pytorch/vision.git" && \
+
     $PIP_INSTALL \
         torch_nightly -f \
         https://download.pytorch.org/whl/nightly/cu100/torch_nightly.html \

--- a/docker/Dockerfile.pytorch-py36-cpu
+++ b/docker/Dockerfile.pytorch-py36-cpu
@@ -78,8 +78,12 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
         enum34 \
         pyyaml \
         typing \
-    	torchvision_nightly \
+    	torch \
         && \
+
+    $PIP_INSTALL \
+    "git+https://github.com/pytorch/vision.git" && \
+
     $PIP_INSTALL \
         torch_nightly -f \
         https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html \

--- a/docker/Dockerfile.pytorch-py36-cu100
+++ b/docker/Dockerfile.pytorch-py36-cu100
@@ -78,8 +78,12 @@ RUN APT_INSTALL="apt-get install -y --no-install-recommends" && \
         enum34 \
         pyyaml \
         typing \
-    	torchvision_nightly \
+    	torch \
         && \
+
+    $PIP_INSTALL \
+    "git+https://github.com/pytorch/vision.git" && \
+
     $PIP_INSTALL \
         torch_nightly -f \
         https://download.pytorch.org/whl/nightly/cu100/torch_nightly.html \

--- a/generator/modules/pytorch.py
+++ b/generator/modules/pytorch.py
@@ -18,8 +18,10 @@ class Pytorch(Module):
                 enum34 \
                 pyyaml \
                 typing \
-            	torchvision_nightly \
+            	torch \
                 && \
+            $PIP_INSTALL \
+            "git+https://github.com/pytorch/vision.git" && \
             $PIP_INSTALL \
                 torch_nightly -f \
                 https://download.pytorch.org/whl/nightly/%s/torch_nightly.html \


### PR DESCRIPTION
According to [pytorch/vision/#833](https://github.com/pytorch/vision/issues/833) the PyPI package is now missing.
So I had to get it from Github vision's repo.