### PR TITLE
Add libssl-dev to fix Openssl header issue

### DIFF
--- a/generator/modules/tools.py
+++ b/generator/modules/tools.py
@@ -17,6 +17,7 @@ class Tools(Module):
                 wget \
                 git \
                 vim \
+                libssl-dev \
                 curl \
                 unzip \
                 unrar \


### PR DESCRIPTION
Fixes #114. The latest version of CMake is having trouble finding the OpenSSL headers.